### PR TITLE
HZC-1745: Relaxed version requirements to minor (not patch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-hazelcast-python-client[stats]~=4.0.0
+hazelcast-python-client[stats]~=4.0


### PR DESCRIPTION
A timeout fix was present in 4.1, this allows to download the latest 4.2.1 release