### PR TITLE
HZC-3702: Clean up the 'cities' map before putting the data

### DIFF
--- a/client.py
+++ b/client.py
@@ -76,6 +76,13 @@ def create_mapping(client: HazelcastClient) -> None:
 
 
 def populate_cities(client: HazelcastClient) -> None:
+    print("Cleaning up the 'cities' map...", end="")
+    try:
+        client.sql.execute("DELETE FROM cities").result()
+        print("OK.")
+    except Exception as e:
+        print(f"FAILED: {e!s}.")
+
     print("Inserting data via SQL...", end="")
 
     insert_query = """

--- a/client_with_ssl.py
+++ b/client_with_ssl.py
@@ -78,6 +78,13 @@ def create_mapping(client: HazelcastClient) -> None:
 
 
 def populate_cities(client: HazelcastClient) -> None:
+    print("Cleaning up the 'cities' map...", end="")
+    try:
+        client.sql.execute("DELETE FROM cities").result()
+        print("OK.")
+    except Exception as e:
+        print(f"FAILED: {e!s}.")
+
     print("Inserting data via SQL...", end="")
 
     insert_query = """


### PR DESCRIPTION
To avoid the following error after running the default sample for the second time:
```
com.hazelcast.jet.JetException: Execution on a member failed: com.hazelcast.jet.JetException: Exception in ProcessorTasklet{0a25-8151-5706-0001/IMap[public.cities]#0}: com.hazelcast.sql.impl.QueryException: Duplicate key.
```